### PR TITLE
Map similar-items ResultIterable to a list to allow sorting

### DIFF
--- a/algorithms/itemBasedRecommender.py
+++ b/algorithms/itemBasedRecommender.py
@@ -163,6 +163,7 @@ if __name__ == "__main__":
     item_sims = pairwise_items.map(
         lambda p: calcSim(p[0],p[1])).map(
         lambda p: keyOnFirstItem(p[0],p[1])).groupByKey().map(
+        lambda p : (p[0], list(p[1]))).map(
         lambda p: nearestNeighbors(p[0],p[1],50)).collect()
 
     '''


### PR DESCRIPTION
groupByKey() returns a ResultIterable object. For allowing sorting on similar items, it should be [mapped to a list](http://stackoverflow.com/q/29717257/2739026). 